### PR TITLE
add PipeClear

### DIFF
--- a/redis/client.go
+++ b/redis/client.go
@@ -124,6 +124,29 @@ func (c *Client) PipeResp() *Resp {
 	return c.PipeResp()
 }
 
+// PipeClear clears all the content in the current pipeline queue, including
+// calls batched by PipeAppend but haven't been sent or replies from the redis
+// server but haven't been returned by PipeResp.
+//
+// 0 is returned if there is nothing in the pipeline queue.
+// A positive value is returned if any pending call is cleared;
+// A negative value is returned if any pending reply is cleared.
+// The absolute value of the return-value indicates the number of
+// calls/replies that have been cleared.
+func (c *Client) PipeClear() int {
+	r := len(c.completed)
+	if r > 0 {
+		c.completed = nil
+		return -r
+	}
+	r = len(c.pending)
+	if r > 0 {
+		c.pending = nil
+		return r
+	}
+	return 0
+}
+
 // ReadResp will read a Resp off of the connection without sending anything
 // first (useful after you've sent a SUSBSCRIBE command). This will block until
 // a reply is received or the timeout is reached (returning the IOErr). You can

--- a/redis/client.go
+++ b/redis/client.go
@@ -125,26 +125,20 @@ func (c *Client) PipeResp() *Resp {
 }
 
 // PipeClear clears all the content in the current pipeline queue, including
-// calls batched by PipeAppend but haven't been sent or replies from the redis
+// calls batched by PipeAppend but haven't been sent and replies from the redis
 // server but haven't been returned by PipeResp.
-//
-// 0 is returned if there is nothing in the pipeline queue.
-// A positive value is returned if any pending call is cleared;
-// A negative value is returned if any pending reply is cleared.
-// The absolute value of the return-value indicates the number of
-// calls/replies that have been cleared.
-func (c *Client) PipeClear() int {
-	r := len(c.completed)
-	if r > 0 {
-		c.completed = nil
-		return -r
-	}
-	r = len(c.pending)
-	if r > 0 {
+// The return value is a pair of integers (callCount, replyCount), indicating
+// the number of pending calls and pending replies that have been cleared by
+// this PipeClear call.
+func (c *Client) PipeClear() (int, int) {
+	callCount, replyCount := len(c.pending), len(c.completed)
+	if callCount > 0 {
 		c.pending = nil
-		return r
 	}
-	return 0
+	if replyCount > 0 {
+		c.completed = nil
+	}
+	return callCount, replyCount
 }
 
 // ReadResp will read a Resp off of the connection without sending anything

--- a/redis/client.go
+++ b/redis/client.go
@@ -124,12 +124,11 @@ func (c *Client) PipeResp() *Resp {
 	return c.PipeResp()
 }
 
-// PipeClear clears all the content in the current pipeline queue, including
-// calls batched by PipeAppend but haven't been sent and replies from the redis
-// server but haven't been returned by PipeResp.
-// The return value is a pair of integers (callCount, replyCount), indicating
-// the number of pending calls and pending replies that have been cleared by
-// this PipeClear call.
+// PipeClient clears the contents of the current pipeline queue, both commands
+// queued by PipeAppend which have yet to be sent and responses which have yet
+// to be retrieved through PipeResp. The first returned int will be the number
+// of pending commands dropped, the second will be the number of pending
+// responses dropped
 func (c *Client) PipeClear() (int, int) {
 	callCount, replyCount := len(c.pending), len(c.completed)
 	if callCount > 0 {

--- a/redis/client_test.go
+++ b/redis/client_test.go
@@ -76,14 +76,16 @@ func TestPipelineClear(t *T) {
 	for i := 0; i < 10; i++ {
 
 		// Clearing an empty pipeline will return 0
-		val := c.PipeClear()
-		assert.Equal(t, 0, val)
+		call, reply := c.PipeClear()
+		assert.Equal(t, 0, call)
+		assert.Equal(t, 0, reply)
 
 		// Clearing pending calls
 		c.PipeAppend("echo", "foo")
 		c.PipeAppend("echo", "bar")
-		val = c.PipeClear()
-		assert.Equal(t, 2, val)
+		call, reply = c.PipeClear()
+		assert.Equal(t, 2, call)
+		assert.Equal(t, 0, reply)
 
 		r := c.PipeResp()
 		assert.Equal(t, AppErr, r.typ)
@@ -102,8 +104,9 @@ func TestPipelineClear(t *T) {
 		require.Nil(t, err)
 		assert.Equal(t, "bar", v)
 
-		val = c.PipeClear()
-		assert.Equal(t, -1, val)
+		call, reply = c.PipeClear()
+		assert.Equal(t, 0, call)
+		assert.Equal(t, 1, reply)
 
 		r = c.PipeResp()
 		assert.Equal(t, AppErr, r.typ)


### PR DESCRIPTION
Clear the content of a pipeline, including pending calls and/or
pending replies. The return value indicates the number of
calls/replies cleared and the sign tells calls and replies apart.
