### PR TITLE
fix GetEvery not automatically putting back clients when error occurred

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -590,6 +590,9 @@ func (c *Cluster) GetEvery() (map[string]*redis.Client, error) {
 		for addr, p := range c.pools {
 			client, err := p.Get()
 			if err != nil {
+				for addr, client := range m {
+					c.pools[addr].Put(client)
+				}
 				respCh <- resp{nil, err}
 				return
 			}


### PR DESCRIPTION
Please let me know if I am missing something.
It looks to me clients are being leaked when an error occurs.
