### PR TITLE
fixed typo in radix.go doc file

### DIFF
--- a/radix.go
+++ b/radix.go
@@ -1,4 +1,4 @@
 // Package radix is a simple redis driver. This top-level package is a wrapper
-// for its sub-packages and doesn't actually contain an code. You likely want to
-// look at the redis sub-package for a straightforward redis client
+// for its sub-packages and doesn't actually contain any code. You likely want
+// to look at the redis sub-package for a straightforward redis client
 package radix


### PR DESCRIPTION
'an' -> 'any' and reformatted comment line to not extend beyond prior longest line (super important stuff, I know)
