### PR TITLE
make network timeouts count as critical network errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 ---
-notifications:
-    email: false
 language: go
 go:
     - 1.4
@@ -21,7 +19,10 @@ install:
 
 before_script:
     # sleep a bit to allow things to get set up
-    - sleep 5
+    - sleep 10
 
 script:
     - go test -v ./...
+
+after_failure:
+    - tail -n100 ./*.log


### PR DESCRIPTION
Initially when determining if an error on a connection was "critical", i.e. the
connection was no longer usable, timeouts shouldn't count because theoretically
it meant that the connection could still be used, like in the case of a pubsub
connection. However what I forgot is that if this happens during a normal
connection, even if the connection becomes usable again it will likely be out of
sync. Let's say the following happens:
- Send commandA
- Timeout waiting for responseA
- Timeout error is returned but ignored because it's not "critical"
- Send commandB
- responseA is finally sent back

Now that connection is truly fucked. So a timeout is a very critical error.

This really only affects the LastCritical field on the connection, so impact
from this non-backwards-compatible change should be very minimal. The only thing
I'm really concerned with is that this will impact someone who is doing pubsub
and using LastCritical for some reason.  I've written pubsub implementations
like 6 different times and have never used it, but I guess it's possible. If you
are one of those people, I'm sorry =/
