### PR TITLE
Export newRespIOErr

### DIFF
--- a/redis/client.go
+++ b/redis/client.go
@@ -79,7 +79,7 @@ func (c *Client) Close() error {
 func (c *Client) Cmd(cmd string, args ...interface{}) *Resp {
 	err := c.writeRequest(request{cmd, args})
 	if err != nil {
-		return newRespIOErr(err)
+		return NewRespIOErr(err)
 	}
 	return c.ReadResp()
 }
@@ -107,7 +107,7 @@ func (c *Client) PipeResp() *Resp {
 	err := c.writeRequest(c.pending...)
 	c.pending = nil
 	if err != nil {
-		return newRespIOErr(err)
+		return NewRespIOErr(err)
 	}
 	c.completed = c.completedHead
 	for i := 0; i < nreqs; i++ {

--- a/redis/resp.go
+++ b/redis/resp.go
@@ -101,8 +101,9 @@ func NewRespFlattenedStrings(v interface{}) *Resp {
 	return &r
 }
 
-// newRespIOErr is a convenience method for making Resps to wrap io errors
-func newRespIOErr(err error) *Resp {
+// NewRespIOErr takes an error and creates an IOErr eesponse. Use NewResp
+// instead to create an AppErr response.
+func NewRespIOErr(err error) *Resp {
 	r := NewResp(err)
 	r.typ = IOErr
 	return r


### PR DESCRIPTION
It's otherwise impossible for a 3rd party library to create an IOErr. I'm using this in order to create a custom pool class that will retry if a pooled connection returns an IOErr. Right now it's only possible to
return an AppErr (if the dial fails), which makes it harder to distinguish between an actual fatal error.
