### PR TITLE
[Pool] Return full pool

### DIFF
--- a/pool/pool.go
+++ b/pool/pool.go
@@ -109,3 +109,8 @@ func (p *Pool) Empty() {
 		}
 	}
 }
+
+// Avail return the number of connections intho the pool
+func (p *Pool) Avail() int {
+	return len(p.pool)
+}


### PR DESCRIPTION
Hi, 

For debugging purposes we want to have access to the Pool.pool field. It's too useful to know how many pools are in the channel and how many are in use.

Is a unexportable field, so it's impossible to access to the pool without this method.

Regards. 
