### PR TITLE
Don't panic when pool size is 0

### DIFF
--- a/pool/pool.go
+++ b/pool/pool.go
@@ -56,6 +56,10 @@ func NewCustom(network, addr string, size int, df DialFunc) (*Pool, error) {
 		p.pool <- pool[i]
 	}
 
+	if size < 1 {
+		return &p, err
+	}
+
 	// set up a go-routine which will periodically ping connections in the pool.
 	// if the pool is idle every connection will be hit once every 10 seconds.
 	go func() {


### PR DESCRIPTION
I ran into a problem with where `pool.New` panics if `size` is 0. This change makes it so an empty pool isn't pinged. This seem like the right behavior (since, if I'm reading the code right, it would make a connection just to ping it).

And, yes, it's silly to make an empty pool. I didn't realize I was, until I started getting "divide by zero" errors this morning. But, it "works", it just doesn't re-use connections.