### PR TITLE
fix connection leak problem when using cluster

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -335,7 +335,7 @@ func (c *Cluster) resetInnerUsingPool(p clusterPool) error {
 		}
 		if slotPool, ok = c.pools[slotAddr]; ok {
 			pools[slotAddr] = slotPool
-		} else {
+		} else if _, ok = pools[slotAddr]; !ok {
 			slotPool, err = c.newPool(slotAddr, true)
 			if err != nil {
 				return err


### PR DESCRIPTION
On reseting the connection pools, the same addr(ip:port) might be created multiple times, and only the last one is used. The formers are discarded.

I'm doing checks before creating new pools.

Thanks!