### PR TITLE
optimize the pool package by limiting connections to a fixed number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ branches:
 
 language: go
 go:
+  - 1.5
   - 1.6
   - 1.7
   - 1.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ branches:
 
 language: go
 go:
-  - 1.5
   - 1.6
   - 1.7
   - 1.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ go:
   - 1.4
   - 1.5
   - 1.6
+  - 1.7
+  - 1.8
+  - 1.9
 
 # getting redis-trib working requires ruby 2.2 or greater
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ branches:
 
 language: go
 go:
-  - 1.4
-  - 1.5
-  - 1.6
   - 1.7
   - 1.8
   - 1.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ branches:
 
 language: go
 go:
+  - 1.4
   - 1.5
   - 1.6
   - 1.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ branches:
 
 language: go
 go:
+  - 1.5
+  - 1.6
   - 1.7
   - 1.8
   - 1.9

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -114,7 +114,7 @@ func (p *Pool) Get() (*redis.Client, error) {
 	// 1.picking a idle connection from the pool;
 	// 2.generating a new connection by dialing to redis cluster.
 	// if this pool is full already,then it will wait util a active connection has been put into pool.
-	// By doing this,we can make sure there
+	// By doing this,we can make sure that there will be always a limited number of connections in pool.
 	case p.running <- true:
 		select {
 		case conn := <-p.pool:

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -106,12 +106,13 @@ func New(network, addr string, size int) (*Pool, error) {
 func (p *Pool) Get() (*redis.Client, error) {
 	select {
 	case conn := <-p.pool:
+		p.running ++
 		return conn, nil
 	default:
-		if p.running  p.capacity{
-
+		if p.capacity == 0 || p.running < p.capacity {
+			return p.df(p.Network, p.Addr)
 		}
-		return p.df(p.Network, p.Addr)
+		return <-p.pool, nil
 	}
 }
 
@@ -122,6 +123,7 @@ func (p *Pool) Put(conn *redis.Client) {
 	if conn.LastCritical == nil {
 		select {
 		case p.pool <- conn:
+			p.running--
 		default:
 			conn.Close()
 		}

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -112,31 +112,17 @@ func (p *Pool) Get() (*redis.Client, error) {
 	// if this pool is full already,then it will wait util a active connection has been put into pool.
 	// By doing this,we can make sure that there will be always a limited number of connections in pool.
 	select {
-	case conn := <-p.pool:
-		p.running <- true
-		return conn, nil
-	default:
+	case p.running <- true:
 		select {
-		case p.running <- true:
-			return p.df(p.Network, p.Addr)
+		case conn := <-p.pool:
+			return conn, nil
 		default:
-			p.running <- true
-			return <-p.pool, nil
+			return p.df(p.Network, p.Addr)
 		}
+	default:
+		p.running <- true
+		return <-p.pool, nil
 	}
-	// another implementation
-	// select {
-	// case p.running <- true:
-	// 	select {
-	// 	case conn := <-p.pool:
-	// 		return conn, nil
-	// 	default:
-	// 		return p.df(p.Network, p.Addr)
-	// 	}
-	// default:
-	// 	p.running <- true
-	// 	return <-p.pool, nil
-	// }
 }
 
 // Put returns a client back to the pool. If the pool is full the client is
@@ -145,18 +131,11 @@ func (p *Pool) Get() (*redis.Client, error) {
 func (p *Pool) Put(conn *redis.Client) {
 	if conn.LastCritical == nil {
 		select {
-		case p.pool <- conn:
-			<-p.running
+		case <-p.running:
+			p.pool <- conn
 		default:
 			conn.Close()
 		}
-		// another implementation
-		// select {
-		// case <-p.running:
-		// 	p.pool <- conn
-		// default:
-		// 	conn.Close()
-		// }
 	}
 }
 

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -108,13 +108,13 @@ func New(network, addr string, size int) (*Pool, error) {
 // Get retrieves an available redis client. If there are none available it will
 // create a new one on the fly
 func (p *Pool) Get() (*redis.Client, error) {
-	select {
 	// Detect whether the pool is full and all connections are active,if not,
 	// return a connection,three are two ways to get a connections:
 	// 1.picking a idle connection from the pool;
 	// 2.generating a new connection by dialing to redis cluster.
 	// if this pool is full already,then it will wait util a active connection has been put into pool.
 	// By doing this,we can make sure that there will be always a limited number of connections in pool.
+	select {
 	case p.running <- true:
 		select {
 		case conn := <-p.pool:

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -48,6 +48,7 @@ func NewCustom(network, addr string, size int, df DialFunc) (*Pool, error) {
 	if size < 1 {
 		return &p, nil
 	}
+	defer close(p.initDoneCh)
 
 	// set up a go-routine which will periodically ping connections in the pool.
 	// if the pool is idle every connection will be hit once every 10 seconds.
@@ -90,7 +91,6 @@ func NewCustom(network, addr string, size int, df DialFunc) (*Pool, error) {
 	//	}
 	//	close(p.initDoneCh)
 	//}()
-
 	return &p, nil
 }
 
@@ -109,7 +109,6 @@ func (p *Pool) Get() (*redis.Client, error) {
 	case p.running <- true:
 		select {
 		case conn := <-p.pool:
-			p.running <- true
 			return conn, nil
 		default:
 			return p.df(p.Network, p.Addr)

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -23,6 +23,8 @@ type Pool struct {
 	// whatever was passed into the New function. These should not be
 	// changed after the pool is initialized
 	Network, Addr string
+	capacity      int
+	running       int
 }
 
 // DialFunc is a function which can be passed into NewCustom
@@ -39,6 +41,7 @@ func NewCustom(network, addr string, size int, df DialFunc) (*Pool, error) {
 		df:         df,
 		initDoneCh: make(chan bool),
 		stopCh:     make(chan bool),
+		capacity:   size,
 	}
 
 	if size < 1 {
@@ -105,6 +108,9 @@ func (p *Pool) Get() (*redis.Client, error) {
 	case conn := <-p.pool:
 		return conn, nil
 	default:
+		if p.running  p.capacity{
+
+		}
 		return p.df(p.Network, p.Addr)
 	}
 }

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -15,9 +15,8 @@ type Pool struct {
 	pool chan *redis.Client
 	df   DialFunc
 
-	initDoneCh chan bool // used for tests
-	stopOnce   sync.Once
-	stopCh     chan bool
+	stopOnce sync.Once
+	stopCh   chan bool
 
 	// The network/address that the pool is connecting to. These are going to be
 	// whatever was passed into the New function. These should not be
@@ -38,20 +37,18 @@ type DialFunc func(network, addr string) (*redis.Client, error)
 // authentication for new connections.
 func NewCustom(network, addr string, size int, df DialFunc) (*Pool, error) {
 	p := Pool{
-		Network:    network,
-		Addr:       addr,
-		pool:       make(chan *redis.Client, size),
-		df:         df,
-		initDoneCh: make(chan bool),
-		stopCh:     make(chan bool),
-		capacity:   size,
-		running:    make(chan bool, size),
+		Network:  network,
+		Addr:     addr,
+		pool:     make(chan *redis.Client, size),
+		df:       df,
+		stopCh:   make(chan bool),
+		capacity: size,
+		running:  make(chan bool, size),
 	}
 
 	if size < 1 {
 		return &p, nil
 	}
-	defer close(p.initDoneCh)
 
 	// set up a go-routine which will periodically ping connections in the pool.
 	// if the pool is idle every connection will be hit once every 10 seconds.
@@ -179,4 +176,9 @@ func (p *Pool) Empty() {
 // be creating new connections on the fly
 func (p *Pool) Avail() int {
 	return len(p.pool)
+}
+
+//Capacity returns the pool size
+func (p *Pool) Capacity() int {
+	return p.capacity
 }

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -134,8 +134,8 @@ func (p *Pool) Get() (*redis.Client, error) {
 func (p *Pool) Put(conn *redis.Client) {
 	if conn.LastCritical == nil {
 		select {
-		case <-p.running:
-			p.pool <- conn
+		case p.pool <- conn:
+			<-p.running
 		default:
 			conn.Close()
 		}

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -167,6 +167,7 @@ func (p *Pool) Empty() {
 		select {
 		case conn = <-p.pool:
 			conn.Close()
+		case <-p.running:
 		default:
 			return
 		}

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -33,14 +33,18 @@ func TestPool(t *T) {
 		}()
 	}
 
+	t.Logf("active connections number:%d", len(pool.running))
 	for {
-		t.Logf("active connections number:%d", len(pool.running))
+		if activeNum := len(pool.running); activeNum < size {
+			t.Logf("active connections number:%d", activeNum)
+		}
 		select {
 		case conn := <-conns:
 			pool.Put(conn)
 		default:
 		}
-		if len(done) == concurrent {
+		if len(done) == concurrent && len(conns) == 0 {
+			t.Logf("active connections number:%d", len(pool.running))
 			break
 		}
 	}

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 func TestPool(t *T) {
-	size := 100
+	size := 10
 	pool, err := New("tcp", "localhost:6379", size)
 	require.Nil(t, err)
 	<-pool.initDoneCh
 
-	concurrent := 1000
+	concurrent := 100
 	var wg sync.WaitGroup
 	conns := make(chan *redis.Client, concurrent)
 	for i := 0; i < concurrent; i++ {

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -22,10 +22,10 @@ func TestPool(t *T) {
 		wg.Add(1)
 		go func() {
 			conn, err := pool.Get()
-			conns <- conn
 			assert.Nil(t, err)
 
 			assert.Nil(t, conn.Cmd("ECHO", "HI").Err)
+			conns <- conn
 
 			//pool.Put(conn)
 			wg.Done()

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -14,7 +14,10 @@ func TestPool(t *T) {
 	pool, err := New("tcp", "localhost:6379", size)
 	require.Nil(t, err)
 	<-pool.initDoneCh
-	pool.stopCh <- true
+	pool.stopOnce.Do(func() {
+		pool.stopCh <- true
+		<-pool.stopCh
+	})
 
 	concurrent := 100
 	var wg sync.WaitGroup

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -14,6 +14,7 @@ func TestPool(t *T) {
 	pool, err := New("tcp", "localhost:6379", size)
 	require.Nil(t, err)
 	<-pool.initDoneCh
+	pool.stopCh <- true
 
 	concurrent := 100
 	var wg sync.WaitGroup

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -14,10 +14,7 @@ func TestPool(t *T) {
 	pool, err := New("tcp", "localhost:6379", size)
 	require.Nil(t, err)
 	<-pool.initDoneCh
-	pool.stopOnce.Do(func() {
-		pool.stopCh <- true
-		<-pool.stopCh
-	})
+	pool.Empty()
 
 	concurrent := 100
 	var wg sync.WaitGroup

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -33,7 +33,7 @@ func TestPool(t *T) {
 		}()
 	}
 	for {
-		if assert.Equal(t, 0, len(pool.pool)) && assert.Equal(t, size, len(pool.running)) {
+		if assert.Equal(t, size, len(pool.running)) {
 			for {
 				select {
 				case conn := <-conns:

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -13,7 +13,6 @@ func TestPool(t *T) {
 	size := 10
 	pool, err := New("tcp", "localhost:6379", size)
 	require.Nil(t, err)
-	<-pool.initDoneCh
 
 	concurrent := 100
 	var wg sync.WaitGroup
@@ -80,7 +79,6 @@ func TestCmd(t *T) {
 func TestPut(t *T) {
 	pool, err := New("tcp", "localhost:6379", 10)
 	require.Nil(t, err)
-	<-pool.initDoneCh
 	var conns []*redis.Client
 	for i := 0; i < 10; i++ {
 		conn, err := pool.Get()

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -34,6 +34,7 @@ func TestPool(t *T) {
 	}
 
 	for {
+		t.Logf("active connections number:%d", len(pool.running))
 		select {
 		case conn := <-conns:
 			pool.Put(conn)

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -33,28 +33,24 @@ func TestPool(t *T) {
 			wg.Done()
 		}()
 	}
-	flag := true
-	run := true
-	go func() {
-		for flag {
-			if assert.Equal(t, 0, len(pool.pool)) && assert.Equal(t, size, len(pool.running)) {
-				for run {
-					select {
-					case conn := <-conns:
-						pool.Put(conn)
-					default:
-						if len(done) == concurrent {
-							run = false
-						}
-					}
+	for {
+		if assert.Equal(t, 0, len(pool.pool)) && assert.Equal(t, size, len(pool.running)) {
+			for {
+				select {
+				case conn := <-conns:
+					pool.Put(conn)
+				default:
+				}
+				if len(done) == concurrent {
+					break
 				}
 			}
 		}
-	}()
-	wg.Wait()
-	if !run {
-		flag = false
+		if len(done) == concurrent {
+			break
+		}
 	}
+	wg.Wait()
 	assert.Equal(t, size, len(pool.pool))
 	assert.Equal(t, 0, len(pool.running))
 

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -32,18 +32,12 @@ func TestPool(t *T) {
 			wg.Done()
 		}()
 	}
+
 	for {
-		if assert.Equal(t, size, len(pool.running)) {
-			for {
-				select {
-				case conn := <-conns:
-					pool.Put(conn)
-				default:
-				}
-				if len(done) == concurrent {
-					break
-				}
-			}
+		select {
+		case conn := <-conns:
+			pool.Put(conn)
+		default:
 		}
 		if len(done) == concurrent {
 			break


### PR DESCRIPTION
Hi @mediocregopher ,i have found that there may be some problems in the pool package of radix.v2 during my use of this package.

Here is the thing,i once ran a program that would init a redis pool with limited size 100,and the program would generate more than 1000 goroutines to get redis connections and unexpectedly, the pool package didn't limit the number of connections to the fixed size which was assigned when initializing the pool instance,this case cause a shutdown of my redis server because it received too many connecting requests.

Then i checked out the source codes of radix.v2 and i found that the pool package would return an available redis client,if there are none available it will create a new one,this kind of implementation may get some potential problems,like i said above,it may create too many connections with redis server at the same time and a shutdown of redis may occured.Besides,creating all connections(pool size) when init a redis pool may not be a very good way to init a redis pool,it may appear wasteful.
 
In summary,i am trying to optimize this pool package,make it possible that pool instance always generate the fixed number of connections which (i think) will prevent redis server from crashing.

please check my pr out,and I'm looking forward to receiving your reply,thanks!
