### PR TITLE
Redis SSL connections

### DIFF
--- a/redis/client.go
+++ b/redis/client.go
@@ -73,10 +73,10 @@ func DialTimeout(network, addr string, timeout time.Duration) (*Client, error) {
 
 // NewClient initializes a Client instance with a preexisting net.Conn.
 //
-// For example, It can be used to open SSL connections to Redis servers:
+// For example, it can be used to open SSL connections to Redis servers:
 //
-//	conn, err := tls.DialWithDialer(&net.Dialer{}, "tcp", addr, &tls.Config{})
-//	client, err = radix.NewClient(conn)
+//	conn, err := tls.Dial("tcp", addr, &tls.Config{})
+//	client, err := radix.NewClient(conn)
 func NewClient(conn net.Conn) (*Client, error) {
 	addr := conn.RemoteAddr()
 	completed := make([]*Resp, 0, 10)

--- a/redis/client.go
+++ b/redis/client.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"bytes"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -62,6 +63,11 @@ func DialTimeout(network, addr string, timeout time.Duration) (*Client, error) {
 		return nil, err
 	}
 
+	return dialTimeout(conn, network, addr, timeout)
+}
+
+// dialTimeout initializes a Client instance with a preexisting net.Conn
+func dialTimeout(conn net.Conn, network, addr string, timeout time.Duration) (*Client, error) {
 	completed := make([]*Resp, 0, 10)
 	return &Client{
 		conn:          conn,
@@ -80,6 +86,15 @@ func DialTimeout(network, addr string, timeout time.Duration) (*Client, error) {
 // Dial connects to the given Redis server.
 func Dial(network, addr string) (*Client, error) {
 	return DialTimeout(network, addr, time.Duration(0))
+}
+
+func DialTLS(network, addr string, tlsConfig tls.Config) (*Client, error) {
+	conn, err := tls.Dial(network, addr, &tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return dialTimeout(conn, network, addr, time.Duration(0))
 }
 
 // Close closes the connection.

--- a/redis/client.go
+++ b/redis/client.go
@@ -88,13 +88,15 @@ func Dial(network, addr string) (*Client, error) {
 	return DialTimeout(network, addr, time.Duration(0))
 }
 
-func DialTLS(network, addr string, tlsConfig tls.Config) (*Client, error) {
-	conn, err := tls.Dial(network, addr, &tlsConfig)
+// DialTLSTimeout connects to the given Redis server using a TLS connection.
+func DialTLSTimeout(network, addr string, tlsConfig tls.Config, timeout time.Duration) (*Client, error) {
+	d := net.Dialer{Timeout: timeout}
+	conn, err := tls.DialWithDialer(&d, network, addr, &tlsConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	return dialTimeout(conn, network, addr, time.Duration(0))
+	return dialTimeout(conn, network, addr, timeout)
 }
 
 // Close closes the connection.

--- a/redis/client.go
+++ b/redis/client.go
@@ -71,7 +71,12 @@ func DialTimeout(network, addr string, timeout time.Duration) (*Client, error) {
 	return client, nil
 }
 
-// NewClient initializes a Client instance with a preexisting net.Conn
+// NewClient initializes a Client instance with a preexisting net.Conn.
+//
+// For example, It can be used to open SSL connections to Redis servers:
+//
+//	conn, err := tls.DialWithDialer(&net.Dialer{}, "tcp", addr, &tls.Config{})
+//	client, err = radix.NewClient(conn)
 func NewClient(conn net.Conn) (*Client, error) {
 	addr := conn.RemoteAddr()
 	completed := make([]*Resp, 0, 10)


### PR DESCRIPTION
This pull request creates a new method `DialTLSTimeout()` which uses

    conn, err := tls.Dial(network, addr, &tlsConfig)

...instead of...

        conn, err := net.DialTimeout(network, addr, timeout)

It allows to use a SSL socket to a Redis server.