### PR TITLE
Optional rate limiting of new connections and help prevent churn

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -195,7 +195,7 @@ func (c *Cluster) spin() {
 // is set. If the given pool couldn't be used a connection from a random pool
 // will (attempt) to be returned
 func (c *Cluster) getConn(key, addr string) (*redis.Client, error) {
-	respCh := make(chan clusterPool)
+	respCh := make(chan clusterPool, 1)
 	c.callCh <- func(c *Cluster) {
 		if key != "" {
 			addr = keyToAddr(key, &c.mapping)
@@ -219,7 +219,7 @@ func (c *Cluster) getConn(key, addr string) (*redis.Client, error) {
 // Put putss the connection back in its pool. To be used alongside any of the
 // Get* methods once use of the redis.Client is done
 func (c *Cluster) Put(conn *redis.Client) {
-	respCh := make(chan clusterPool)
+	respCh := make(chan clusterPool, 1)
 	c.callCh <- func(c *Cluster) {
 		respCh <- c.pools[conn.Addr]
 	}
@@ -246,7 +246,7 @@ func (c *Cluster) getRandomPoolInner() clusterPool {
 // the same time and it will only actually occur once (subsequent clients will
 // have nil returned immediately).
 func (c *Cluster) Reset() error {
-	respCh := make(chan error)
+	respCh := make(chan error, 1)
 	c.callCh <- func(c *Cluster) {
 		respCh <- c.resetInner()
 	}
@@ -555,7 +555,7 @@ func (c *Cluster) GetEvery() (map[string]*redis.Client, error) {
 		m   map[string]*redis.Client
 		err error
 	}
-	respCh := make(chan resp)
+	respCh := make(chan resp, 1)
 	c.callCh <- func(c *Cluster) {
 		m := map[string]*redis.Client{}
 		for addr, p := range c.pools {
@@ -580,7 +580,7 @@ func (c *Cluster) GetEvery() (map[string]*redis.Client, error) {
 // calling Avail on that instance's Pool instance. See pool.Avail for specifics
 // on what Avail means.
 func (c *Cluster) GetEveryAvail() map[string]int {
-	respCh := make(chan map[string]int)
+	respCh := make(chan map[string]int, 1)
 	c.callCh <- func(c *Cluster) {
 		m := map[string]int{}
 		for addr, p := range c.pools {
@@ -594,7 +594,7 @@ func (c *Cluster) GetEveryAvail() map[string]int {
 // GetAddrForKey returns the address which would be used to handle the given key
 // in the cluster.
 func (c *Cluster) GetAddrForKey(key string) string {
-	respCh := make(chan string)
+	respCh := make(chan string, 1)
 	c.callCh <- func(c *Cluster) {
 		respCh <- keyToAddr(key, &c.mapping)
 	}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -79,6 +79,9 @@ type Opts struct {
 	// The size of the connection pool to use for each host. Default is 10
 	PoolSize int
 
+	// PoolOpts contain optional Opt's to pass to pool.NewCustom
+	PoolOpts []pool.Opt
+
 	// The time which must elapse between subsequent calls to create a new
 	// connection pool (on a per redis instance basis) in certain circumstances.
 	// The default is 500 milliseconds
@@ -170,7 +173,7 @@ func (c *Cluster) newPool(addr string, clearThrottle bool) (clusterPool, error) 
 	df := func(network, addr string) (*redis.Client, error) {
 		return c.o.Dialer(network, addr)
 	}
-	p, err := pool.NewCustom("tcp", addr, c.o.PoolSize, df)
+	p, err := pool.NewCustom("tcp", addr, c.o.PoolSize, df, c.o.PoolOpts...)
 	if err != nil {
 		c.poolThrottles[addr] = time.After(c.o.PoolThrottle)
 		return clusterPool{}, err

--- a/pool/doc.go
+++ b/pool/doc.go
@@ -26,6 +26,14 @@
 //
 //	p.Put(conn)
 //
+// Options
+//
+// Various options can be sent to NewCustom to modify the behavior of the pool.
+// Be default, the pool pings a connection every 10/size seconds, creates an
+// unlimited amount of new connections and does not buffer created connections
+// if the pool is full. Each of these can be modified by sending one or more
+// Opt functions to NewCustom.
+//
 // Shortcuts
 //
 // If you're doing multiple operations you may find it useful to defer the Put

--- a/pool/opts.go
+++ b/pool/opts.go
@@ -1,0 +1,73 @@
+package pool
+
+import "time"
+
+type opts struct {
+	pingInterval          time.Duration
+	createLimitBuffer     int
+	createLimitInterval   time.Duration
+	overflowDrainInterval time.Duration
+	overflowSize          int
+}
+
+// Opt is an optional behavior which can be applied to the NewCustom
+// function to effect a Pool's behavior
+type Opt func(*opts)
+
+// PingInterval specifies the interval at which a ping event happens. On
+// each ping event the Pool calls the PING redis command over one of it's
+// available connections.
+//
+// Since connections are used in LIFO order, the ping interval * pool size is
+// the duration of time it takes to ping every connection once when the pool is
+// idle.
+//
+// A shorter interval means connections are pinged more frequently, but also
+// means more traffic with the server.
+//
+// An interval of 0 disables pinging and is highly discouraged.
+func PingInterval(d time.Duration) Opt {
+	return func(po *opts) {
+		po.pingInterval = d
+	}
+}
+
+// OnFullBuffer effects the Pool's behavior when it is full. The effect is
+// to cause any connection which is being put back into a full pool to be put
+// instead into an overflow buffer which can hold up to the given number of
+// connections. If the overflow buffer is also full then the connection is
+// closed and discarded.
+//
+// drainInterval specifies the interval at which a drain event happens. On each
+// drain event a connection is removed from the overflow buffer and put into the
+// pool. If the pool is full the connection is closed and discarded.
+//
+// When Actions are performed with the Pool the connection used may come from
+// either the main pool or the overflow buffer. Connections do _not_ have to
+// wait to be drained into the main pool before they will be used.
+func OnFullBuffer(size int, drainInterval time.Duration) Opt {
+	return func(po *opts) {
+		po.overflowSize = size
+		po.overflowDrainInterval = drainInterval
+	}
+}
+
+// CreateLimit effects the Pool's create behavior when the pool is empty. The
+// effect is to limit any connection creation to at most one every interval
+// after headroom has been exhausted. When a request comes in and the pool is
+// empty, new connections will be created as fast as necessary until the
+// headroom is depleated and then any new requests will be blocked until
+// interval happens.
+//
+// Typically you'll want some headroom over the pool size to allow a burst of
+// traffic to be satisfied as quickly as possible but then limit creation after
+// that initial headroom.
+//
+// Setting the interval to 0 disables any creation limits. Setting the headroom
+// to 0 disables any headroom and all creation will be limited by the interval.
+func CreateLimit(headroom int, createInterval time.Duration) Opt {
+	return func(po *opts) {
+		po.createLimitBuffer = headroom
+		po.createLimitInterval = createInterval
+	}
+}

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -7,13 +7,21 @@ import (
 	"github.com/mediocregopher/radix.v2/redis"
 )
 
-// Pool is a simple connection pool for redis Clients. It will create a small
-// pool of initial connections, and if more connections are needed they will be
+// Pool is a connection pool for redis Clients. It will create a small pool of
+// initial connections, and if more connections are needed they will be
 // created on demand. If a connection is Put back and the pool is full it will
-// be closed.
+// be closed. A reserve pool is kept alongside the main pool to prevent
+// connection churn. If the main pool is filled, a connection is put into the
+// reserve pool and they're slowly (over 100 seconds) evicted from the reserve.
 type Pool struct {
-	pool chan *redis.Client
-	df   DialFunc
+	pool        chan *redis.Client
+	reservePool chan *redis.Client
+	df          DialFunc
+
+	po opts
+
+	// limited channel is read whenever we attempt to make a new client
+	limited chan bool
 
 	initDoneCh chan bool // used for tests
 	stopCh     chan bool
@@ -30,39 +38,121 @@ type DialFunc func(network, addr string) (*redis.Client, error)
 // NewCustom is like New except you can specify a DialFunc which will be
 // used when creating new connections for the pool. The common use-case is to do
 // authentication for new connections.
-func NewCustom(network, addr string, size int, df DialFunc) (*Pool, error) {
-	p := Pool{
-		Network:    network,
-		Addr:       addr,
-		pool:       make(chan *redis.Client, size),
-		df:         df,
-		initDoneCh: make(chan bool),
-		stopCh:     make(chan bool),
+func NewCustom(network, addr string, size int, df DialFunc, os ...Opt) (*Pool, error) {
+	var defaultPoolOpts []Opt
+	// if pool size is 0 don't do any pinging, cause there'd be no point
+	if size > 0 {
+		defaultPoolOpts = append(defaultPoolOpts, PingInterval(10*time.Second/time.Duration(size)))
 	}
 
-	if size < 1 {
-		return &p, nil
+	var po opts
+	for _, opt := range append(defaultPoolOpts, os...) {
+		opt(&po)
+	}
+
+	p := Pool{
+		Network:     network,
+		Addr:        addr,
+		po:          po,
+		pool:        make(chan *redis.Client, size),
+		reservePool: make(chan *redis.Client, po.overflowSize),
+		limited:     make(chan bool, po.createLimitBuffer),
+		df:          df,
+		initDoneCh:  make(chan bool),
+		stopCh:      make(chan bool),
+	}
+
+	// we do some weird defer/wait stuff to ensure thsee goroutines alway start no
+	// matter what happens with the rest of the initialization
+	startTickCh := make(chan struct{})
+	defer close(startTickCh)
+
+	doEvery := func(i time.Duration, do func()) {
+		go func() {
+			tick := time.NewTicker(i)
+			defer tick.Stop()
+			<-startTickCh
+			for {
+				select {
+				case <-p.stopCh:
+					return
+				case <-tick.C:
+					do()
+				}
+			}
+		}()
 	}
 
 	// set up a go-routine which will periodically ping connections in the pool.
 	// if the pool is idle every connection will be hit once every 10 seconds.
-	// we do some weird defer/wait stuff to ensure this always gets started no
-	// matter what happens with the rest of the initialization
-	startTickCh := make(chan struct{})
-	defer close(startTickCh)
-	go func() {
-		tick := time.NewTicker(10 * time.Second / time.Duration(size))
-		defer tick.Stop()
-		<-startTickCh
-		for {
+	if po.pingInterval > 0 {
+		doEvery(po.pingInterval, func() {
+			// instead of using Cmd/Get, which might make a new connection,
+			// we only check from the pool
 			select {
-			case <-p.stopCh:
-				return
-			case <-tick.C:
-				p.Cmd("PING")
+			case conn := <-p.pool:
+				// we don't care if PING errors since Put will handle that
+				conn.Cmd("PING")
+				p.Put(conn)
+			default:
 			}
-		}
-	}()
+		})
+	}
+
+	// additionally, if there are any connections in the reserve pool, they're closed
+	// periodically depending on the drain interval
+	if po.overflowSize > 0 {
+		doEvery(po.overflowDrainInterval, func() {
+			// remove one from the reservePool, if there is any, and try putting it
+			// into the main pool
+			select {
+			case conn := <-p.reservePool:
+				select {
+				case p.pool <- conn:
+				default:
+					// if the main pool is full then just close it
+					conn.Close()
+				}
+			default:
+			}
+		})
+	}
+
+	if po.createLimitInterval > 0 {
+		go func() {
+			// until we're done seeding, allow it to make as fast as possible
+		seedLoop:
+			for {
+				select {
+				case <-p.stopCh:
+					return
+				case <-startTickCh:
+					break seedLoop
+				case p.limited <- true:
+				}
+			}
+
+			// now we only refill the bucket every interval, but we can't use a
+			// ticker because that'll overflow while we're blocked on writing to
+			// the limited channel
+			for {
+				select {
+				case <-time.After(po.createLimitInterval):
+					// now try to fill the bucket but we might block if its already
+					// filled
+					select {
+					case <-p.stopCh:
+						return
+					case p.limited <- true:
+					}
+				case <-p.stopCh:
+					return
+				}
+			}
+		}()
+	} else {
+		close(p.limited)
+	}
 
 	mkConn := func() error {
 		client, err := df(network, addr)
@@ -72,9 +162,11 @@ func NewCustom(network, addr string, size int, df DialFunc) (*Pool, error) {
 		return err
 	}
 
-	// make one connection to make sure the redis instance is actually there
-	if err := mkConn(); err != nil {
-		return &p, err
+	if size > 0 {
+		// make one connection to make sure the redis instance is actually there
+		if err := mkConn(); err != nil {
+			return &p, err
+		}
 	}
 
 	// make the rest of the connections in the background, if any fail it's fine
@@ -102,10 +194,22 @@ func (p *Pool) Get() (*redis.Client, error) {
 	select {
 	case conn := <-p.pool:
 		return conn, nil
+	case conn := <-p.reservePool:
+		return conn, nil
 	case <-p.stopCh:
 		return nil, errors.New("pool emptied")
 	default:
-		return p.df(p.Network, p.Addr)
+		// we need a separate select here since it's indeterminate which case go
+		// will select and we want to always prefer pools over creating a new
+		// connection
+		select {
+		case conn := <-p.pool:
+			return conn, nil
+		case conn := <-p.reservePool:
+			return conn, nil
+		case <-p.limited:
+			return p.df(p.Network, p.Addr)
+		}
 	}
 }
 
@@ -125,7 +229,19 @@ func (p *Pool) Put(conn *redis.Client) {
 		select {
 		case p.pool <- conn:
 		default:
-			conn.Close()
+			// if there isn't any overflow allowed, immediately close
+			if p.po.overflowSize == 0 {
+				conn.Close()
+				return
+			}
+
+			// we need a separate select here since it's indeterminate which case go
+			// will select and we want to always prefer the main pool over the reserve
+			select {
+			case p.reservePool <- conn:
+			default:
+				conn.Close()
+			}
 		}
 	}
 }
@@ -159,6 +275,8 @@ func (p *Pool) Empty() {
 		select {
 		case conn = <-p.pool:
 			conn.Close()
+		case conn = <-p.reservePool:
+			conn.Close()
 		default:
 			return
 		}
@@ -167,7 +285,7 @@ func (p *Pool) Empty() {
 
 // Avail returns the number of connections currently available to be gotten from
 // the Pool using Get. If the number is zero then subsequent calls to Get will
-// be creating new connections on the fly
+// be creating new connections on the fly.
 func (p *Pool) Avail() int {
-	return len(p.pool)
+	return len(p.pool) + len(p.reservePool)
 }

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -35,6 +35,10 @@ func TestPool(t *T) {
 
 	pool.Empty()
 	assert.Equal(t, 0, len(pool.pool))
+
+	c, err := pool.Get()
+	assert.Nil(t, c)
+	assert.Error(t, err)
 }
 
 func TestCmd(t *T) {
@@ -72,4 +76,11 @@ func TestPut(t *T) {
 	// Make sure that Put does not accept a connection which has had a critical
 	// network error
 	assert.Equal(t, 9, len(pool.pool))
+
+	// Make sure an emptied pool doesn't get connections added later
+	conn, err = pool.Get()
+	require.Nil(t, err)
+	pool.Empty()
+	pool.Put(conn)
+	assert.Equal(t, 0, len(pool.pool))
 }

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -3,42 +3,193 @@ package pool
 import (
 	"sync"
 	. "testing"
+	"time"
 
+	"github.com/mediocregopher/radix.v2/redis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPool(t *T) {
-	size := 10
+	size := 3
 	pool, err := New("tcp", "localhost:6379", size)
 	require.Nil(t, err)
 	<-pool.initDoneCh
 
-	var wg sync.WaitGroup
-	for i := 0; i < size*4; i++ {
-		wg.Add(1)
-		go func() {
-			for i := 0; i < 100; i++ {
-				conn, err := pool.Get()
-				assert.Nil(t, err)
-
-				assert.Nil(t, conn.Cmd("ECHO", "HI").Err)
-
-				pool.Put(conn)
-			}
-			wg.Done()
-		}()
+	clients := []*redis.Client{}
+	for i := 0; i < size*2; i++ {
+		c, err := pool.Get()
+		require.NoError(t, err)
+		clients = append(clients, c)
 	}
-	wg.Wait()
+	assert.Equal(t, 0, len(pool.pool))
+	assert.Equal(t, 0, len(pool.reservePool))
+	assert.Equal(t, 0, pool.Avail())
 
+	// put size back
+	for i := 0; i < size; i++ {
+		pool.Put(clients[i])
+	}
 	assert.Equal(t, size, len(pool.pool))
+	assert.Equal(t, 0, len(pool.reservePool))
+
+	// put the rest back and they should be closed
+	for i := size; i < len(clients); i++ {
+		pool.Put(clients[i])
+	}
+	assert.Equal(t, size, len(pool.pool))
+	assert.Equal(t, 0, len(pool.reservePool))
 
 	pool.Empty()
 	assert.Equal(t, 0, len(pool.pool))
+	assert.Equal(t, 0, len(pool.reservePool))
+	assert.Equal(t, 0, pool.Avail())
 
 	c, err := pool.Get()
 	assert.Nil(t, c)
 	assert.Error(t, err)
+}
+
+func TestZeroPool(t *T) {
+	pool, err := NewCustom("tcp", "localhost:6379", 0, redis.Dial, OnFullBuffer(1, 2*time.Second))
+	require.Nil(t, err)
+	<-pool.initDoneCh
+
+	c, err := pool.Get()
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(pool.pool))
+	assert.Equal(t, 0, len(pool.reservePool))
+	assert.Equal(t, 0, pool.Avail())
+
+	pool.Put(c)
+	assert.Equal(t, 0, len(pool.pool))
+	assert.Equal(t, 1, len(pool.reservePool))
+
+	pool.Empty()
+	assert.Equal(t, 0, len(pool.pool))
+	assert.Equal(t, 0, len(pool.reservePool))
+	assert.Equal(t, 0, pool.Avail())
+}
+
+func TestBufferedPool(t *T) {
+	size := 3
+	pool, err := NewCustom("tcp", "localhost:6379", size, redis.Dial, OnFullBuffer(30, 2*time.Second))
+	require.Nil(t, err)
+	<-pool.initDoneCh
+
+	clients := []*redis.Client{}
+	for i := 0; i < size+30; i++ {
+		c, err := pool.Get()
+		require.NoError(t, err)
+		clients = append(clients, c)
+	}
+	assert.Equal(t, 0, len(pool.pool))
+	assert.Equal(t, 0, len(pool.reservePool))
+	assert.Equal(t, 0, pool.Avail())
+
+	// put size back
+	for i := 0; i < size; i++ {
+		pool.Put(clients[i])
+	}
+	assert.Equal(t, size, len(pool.pool))
+	assert.Equal(t, 0, len(pool.reservePool))
+
+	// put all of them back
+	for i := size; i < len(clients); i++ {
+		pool.Put(clients[i])
+	}
+	assert.Equal(t, size, len(pool.pool))
+	assert.Equal(t, size*10, len(pool.reservePool))
+
+	// take one out of either the reserve or the normal
+	c, err := pool.Get()
+
+	// wait for the background goroutine to evict from the pool and ensure that
+	// the main pool is full
+	time.Sleep(3 * time.Second)
+	assert.Equal(t, size, len(pool.pool))
+	assert.True(t, len(pool.reservePool) < size*10, "size: %d, expected less than: %d", len(pool.reservePool), size*10)
+
+	// put back the one that we took out earlier and make sure it goes into the
+	// reserve
+	before := len(pool.reservePool)
+	pool.Put(c)
+	assert.Equal(t, before+1, len(pool.reservePool))
+
+	pool.Empty()
+	assert.Equal(t, 0, len(pool.pool))
+	assert.Equal(t, 0, len(pool.reservePool))
+	assert.Equal(t, 0, pool.Avail())
+}
+
+func TestLimitedPool(t *T) {
+	size := 3
+	pool, err := NewCustom("tcp", "localhost:6379", size, redis.Dial, CreateLimit(size, 2*time.Second))
+	require.Nil(t, err)
+	<-pool.initDoneCh
+
+	assert.Equal(t, size, len(pool.limited))
+
+	clients := []*redis.Client{}
+	for i := 0; i < size; i++ {
+		c, err := pool.Get()
+		require.NoError(t, err)
+		clients = append(clients, c)
+	}
+	assert.Equal(t, 0, len(pool.pool))
+	assert.Equal(t, 0, len(pool.reservePool))
+	assert.Equal(t, size, len(pool.limited))
+	assert.Equal(t, 0, pool.Avail())
+
+	for i := 0; i < size; i++ {
+		c, err := pool.Get()
+		require.NoError(t, err)
+		clients = append(clients, c)
+	}
+	assert.Equal(t, 0, len(pool.pool))
+	assert.Equal(t, 0, len(pool.reservePool))
+	assert.Equal(t, 0, len(pool.limited))
+	assert.Equal(t, 0, pool.Avail())
+
+	// we should've used up ALL of our limit so start 2 goroutines to test
+	// putting one back and the token bucket refilling
+	doneCh := make(chan bool, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			c, err := pool.Get()
+			require.NoError(t, err)
+			c.Close()
+			doneCh <- true
+		}()
+	}
+	// sleep a bit for the goroutine to start up and make sure the goroutines are
+	// still waiting for a connection
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 0, len(doneCh))
+
+	// if we put one back that should free up one of the goroutines
+	pool.Put(clients[0])
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 1, len(doneCh))
+	assert.Equal(t, 0, len(pool.limited))
+
+	// now if we 3 seconds we should get another token added to the
+	// bucket and the goroutine should be freed up
+	time.Sleep(3 * time.Second)
+	assert.Equal(t, 2, len(doneCh))
+	// since the goroutine was freed up, it just created one and so the pool
+	// should be back to 0
+	assert.Equal(t, 0, len(pool.limited))
+
+	// close whatever is left
+	for i := 1; i < len(clients); i++ {
+		clients[i].Close()
+	}
+
+	pool.Empty()
+	assert.Equal(t, 0, len(pool.pool))
+	assert.Equal(t, 0, len(pool.reservePool))
+	assert.Equal(t, 0, pool.Avail())
 }
 
 func TestCmd(t *T) {


### PR DESCRIPTION
We've been having an issue in production where thousands of connections are created/closed/repeat within a few seconds and the service runs out of file descriptors (because the old connections are left in TIME_WAIT) and is now in an unusable state. This PR adds a few things:

First, a "reserve pool" was added to `Pool` and has a capacity of `10*size`. If the main pool is full, this reserve pool is used to temporarily hold onto a client in case it is immediately needed again. This should help prevent connection churn if more than `size` connections are needed temporarily. Over a period of 100 seconds, the reserve pool is drained re-using the ping timer.

Second, instead of potentially creating a new connection just to ping, we only look for a client in the pool.

Third, an optional "limited" pool can be created with a token bucket system that only allows `size` clients
to be created roughly every 10 seconds. The bucket is refilled at a rate of `10/size` seconds. This also re-uses the ping timer. I left this default to off since technically it's backward-incompatible but we plan on turning it on in almost all cases. A `PoolLimited` bool was added to the `cluster.Opts` struct to enable this functionality.