### PR TITLE
check "response is nil" when invoke Float64()

### DIFF
--- a/redis/resp.go
+++ b/redis/resp.go
@@ -347,6 +347,9 @@ func (r *Resp) Float64() (float64, error) {
 	if r.Err != nil {
 		return 0, r.Err
 	}
+	if r.IsType(Nil) {
+		return 0, ErrRespNil
+	}
 	if b, ok := r.val.([]byte); ok {
 		f, err := strconv.ParseFloat(string(b), 64)
 		if err != nil {


### PR DESCRIPTION
1. zscore will return "$-1" in protocol when there is no cotent in redis,and it aslo will return a float score
2. `func bufioReadResp(r *bufio.Reader) (Resp, error)` will return `Resp{typ: Nil}, nil` when there is no key in redis
3. `resp.Float64()` did'nt handle this case and return `Resp{typ: Nil}, nil`, client need to handle this special case